### PR TITLE
Update Python version and split reqs in the workflow

### DIFF
--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -19,13 +19,13 @@ jobs:
 
     steps:
     - uses: actions/checkout@v3
-    - name: Set up Python 3.10
+    - name: Set up Python 3.11
       uses: actions/setup-python@v3
       with:
-        python-version: "3.10"
+        python-version: "3.11"
     - name: Install dependencies
       run: |
-        pip install -r requirements.txt
+        pip install -r requirements.txt -r requirements-dev.txt
     - name: Lint with black
       run: |
         black .


### PR DESCRIPTION
Task description says that we must use **Python 3.11**, while this workflow suggest to use **Python 3.10**. Although these versions have no fundamental differences, some of Python 3.11 useful features are missing from the previous version.

Usually, development requirements (like `black` and `pytest`) aren't required to use the project and described in the separate file like `requirements-dev.txt`, so I add it to workflow.